### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 # kfrgb
 
-# Version:    0.5.0
+# Version:    0.6.0
 # Author:     KeyofBlueS
 # Repository: https://github.com/KeyofBlueS/kfrgb
 # License:    GNU General Public License v3.0, https://opensource.org/licenses/GPL-3.0
 
 ### DISCLAIMER
-**Detection of a Kingston Fury Beast DDR5 RAM on a i2c-bus is not implemented, so you must be really sure about the values you enter for --ramslots and --bus.
+**Detection of a 'Kingston Fury Beast DDR5 RGB RAM' on a i2c-bus is not implemented, so you must be really sure about the values you enter for --ramslots and --smbus.
 To find out how to retrieve these values, please refer to https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/2879.
 Even if you enter the correct values, the procedure is still risky!
 This program can confuse your I2C bus, cause data loss or brick your hardware! Proceed AT YOUR OWN RISK!**
@@ -16,13 +16,13 @@ This program can confuse your I2C bus, cause data loss or brick your hardware! P
 While waiting for support to be added to OpenRGB, this script is intended to be used to control RGB Leds of a **Kingston Fury Beast DDR5 RAM ONLY** with the help of i2c-tools.
 
 ### FEATURES
-Set any mode (and their parameters) between rainbow, prism, spectrum, slide, wind, static, static_byledcolor, lightspeed, rain, firework, twilight, teleport, flame, voltage, countdown and rhythm.
+Set any mode (and their parameters) between rainbow, prism, spectrum, slide, wind, static, static_byledcolor, lightspeed, rain, firework, breath, breath_byledcolor, dynamic, twilight, teleport, flame, voltage, countdown and rhythm.
 By using yad, a graphical dialog to choose a color is shown if no\wrong values for them are entered.
 
 Not all modes are fully supported:
-- Modes breath, breath_byledcolor and dynamic: not supported because if set, then you can't set any other mode, you need to turn off the pc (do a cold boot) to 'unlock' (and we lack the hex values to set speed).
 - Mode slither: not supported (we lack the hex values to set this mode and its parameters).
 - Modes twilight, teleport, flame, voltage, countdown and rhythm: we lack the hex values to set any of their parameters, nevertheless i've used values from other modes to set them. It works, but likely not the same way as with the official app.
+- Modes breath, breath_byledcolor and dynamic: we lack the hex values to set speed, values from other modes doesn't work. These modes will run at their default speed or the last speed set by the official app.
 
 ### INSTALL
 ```
@@ -40,10 +40,10 @@ The option --ramslots <ramslots_value> is mandatory. The value equals a ram slot
 You can enter a single value to control a single ram stick or a comma separated set of values to control two or more ram sticks.
 If you enter e.g. --ramslots 2,4 on --bus 0, but you really only have ram 2, ram 4 will be skipped.
 
-If the option `--bus <i2c_bus_number>` is omitted or a wrong/non existent value has been entered, a prompt to select an i2c-bus will be shown.
+If the option `--smbus <smbus_number>` is omitted or a wrong/non existent value has been entered, a prompt to select an i2c-bus will be shown.
 
 Use the option `--mode <mode_name>` to set a mode.
-Available modes are 'rainbow' 'prism' 'spectrum' 'slide' 'wind' 'static' 'static_byledcolor' 'lightspeed' 'rain' 'firework' 'twilight' 'teleport' 'flame' 'voltage' 'countdown' 'rhythm'.
+Available modes are 'rainbow' 'prism' 'spectrum' 'slide' 'wind' 'static' 'static_byledcolor' 'lightspeed' 'rain' 'firework' 'breath' 'breath_byledcolor' 'dynamic' 'twilight' 'teleport' 'flame' 'voltage' 'countdown' 'rhythm'.
 Pass 'list' as <mode_name> to get a menu where you can choose a mode to set.
 
 Speed (min 1, max 11) and brightness (min 0, max 100, default 80) are common for every mode. However every mode has it's own available and default parameters also:
@@ -58,6 +58,9 @@ Speed (min 1, max 11) and brightness (min 0, max 100, default 80) are common for
 - lightspeed: speed (default 9); delay (min 1, max 21, default 1); lenght (min 1, max 18, default 7); tencolors; direction (default up).
 - rain: speed (default 11); tencolors; direction (default down).
 - firework: speed (default 11); tencolors; direction (default up).
+- breath: tencolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
+- breath_byledcolor: byledcolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
+- dynamic: tencolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
 - twilight: speed (default 9).
 - teleport: speed (default 10); lenght (min 1, max 12, default 3); tencolors; backcolor; direction (default up).
 - flame: speed (default 1); direction (default up).
@@ -118,69 +121,69 @@ Option `--off` will turn off leds on the ram. This option will take full priorit
 
 ### EXAMPLES
 
-show a menu where you can select an i2c-bus, then choose a mode to set for ram 2:
+show a menu where you can select an SMBus, then choose a mode to set for RAM 2:
 
 `# kfrgb --ramslots 2`
 
-show a menu where you can choose a mode to set for ram 2 on i2c-bus 0:
+show a menu where you can choose a mode to set for RAM 2 on SMBus 0:
 
-`# kfrgb --ramslots 2 --bus 0`
+`# kfrgb --ramslots 2 --smbus 0`
 
-show a graphical dialog to choose a color with brightness at 70 for ram 2 on i2c-bus 0 without the warning before apply the settings:
+show a graphical dialog to choose a color with brightness at 70 for RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --brightness 70 --mode static --ask --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --brightness 70 --mode static --ask --nowarn`
 
-set a yellow color to ram 2 and 4 on i2c-bus 0 (in this case the options --mode static):
+set a yellow color to RAM 2 and 4 on SMBus 0 (in this case the options --mode static):
 
-`# kfrgb --ramslots 2,4 --bus 0 --color 255,255,0`
+`# kfrgb --ramslots 2,4 --smbus 0 --color 255,255,0`
 
-set a every single led color to ram 2 and 4 on i2c-bus 0:
+set a every single led color to RAM 2 and 4 on SMBus 0:
 
-`# kfrgb --ramslots 2,4 --bus 0 --mode static_byledcolor --byledcolors 255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255`
+`# kfrgb --ramslots 2,4 --smbus 0 --mode static_byledcolor --byledcolors 255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255`
 
-set a every single led to a random color to ram 2 and 4 on i2c-bus 0:
+set a every single led to a random color to RAM 2 and 4 on SMBus 0:
 
-`# kfrgb --ramslots 2,4 --bus 0 --mode static_byledcolor --randomcolor`
+`# kfrgb --ramslots 2,4 --smbus 0 --mode static_byledcolor --randomcolor`
 
-set mode wind with default parameters to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode wind with default parameters to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode wind --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode wind --nowarn`
 
-set mode wind with brightness at 100 and direction down to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode wind with brightness at 100 and direction down to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode wind --brightness 100 --direction down --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode wind --brightness 100 --direction down --nowarn`
 
-set mode wind with backcolor to violet, brightness at 100 and direction down to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode wind with backcolor to violet, brightness at 100 and direction down to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode wind --backcolor 150,70,200 --brightness 100 --direction down --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode wind --backcolor 150,70,200 --brightness 100 --direction down --nowarn`
 
-set mode slide with speed at 8 and direction up to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode slide with speed at 8 and direction up to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode slide --speed 8 --direction up --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode slide --speed 8 --direction up --nowarn`
 
-set mode rainbow with speed at 1 to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode rainbow with speed at 1 to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode rainbow --speed 1 --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode rainbow --speed 1 --nowarn`
 
-set mode slide and 10 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode slide and 10 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0,0,0,255,238,238,0,128,0,128,0,109,119,255,200,0,255,85,255,60,125,255 --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0,0,0,255,238,238,0,128,0,128,0,109,119,255,200,0,255,85,255,60,125,255 --nowarn`
 
-set mode slide and 3 colors (you can omit the remaining 7 colors) to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode slide and 3 colors (you can omit the remaining 7 colors) to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0 --tencolorsnumber 3 --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0 --tencolorsnumber 3 --nowarn`
 
-set mode wind and, asking for user input, 10 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode wind and, asking for user input, 10 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode wind --ask --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode wind --ask --nowarn`
 
-set mode wind and, asking for user input, 3 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
+set mode wind and, asking for user input, 3 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 2 --bus 0 --mode wind --tencolorsnumber 3 --ask --nowarn`
+`# kfrgb --ramslots 2 --smbus 0 --mode wind --tencolorsnumber 3 --ask --nowarn`
 
-Turn off leds to ram 4 on i2c-bus 0 without the warning before apply the settings:
+Turn off leds to RAM 4 on SMBus 0 without the warning before apply the settings:
 
-`# kfrgb --ramslots 4 --bus 0 --off --nowarn`
+`# kfrgb --ramslots 4 --smbus 0 --off --nowarn`
 
 ### NOTE ABOUT COMMA SEPARATED VALUES
 As explained above, RGB values can be set in a comma separated format e.g.:
@@ -196,8 +199,8 @@ I prefer the latter because i can visually separate every RGB triplet.
 
 ```
 Options:
--s, --bus <i2c_bus_number>      Enter the i2c-bus number.
--m, --ramslots <ramslots_value> Enter the comma separated ram slot values. Mandatory.
+-s, --smbus <smbus_number>      Enter the SMBus number.
+-m, --ramslots <ramslots_value> Enter the comma separated RAM slot values. Mandatory.
 -d, --mode <mode>               Enter the name of the mode. Pass 'list' as <mode_name> to get a menu
                                                             where you can choose a mode to set.
 -p, --speed <value>             Enter  1 value between 1 and 11. Default depends on mode.

--- a/kfrgb.sh
+++ b/kfrgb.sh
@@ -2,10 +2,11 @@
 
 # kfrgb
 
-# Version:    0.5.0
+# Version:    0.6.0
 # Author:     KeyofBlueS
 # Repository: https://github.com/KeyofBlueS/kfrgb
 # License:    GNU General Public License v3.0, https://opensource.org/licenses/GPL-3.0
+
 
 function initialize_modes() {
 
@@ -96,7 +97,7 @@ function initialize_modes() {
 	tencolors_default_dynamic='255 0 0,0 255 0,255 100 0,0 0 255,238 238 0,128 0 128,0 109 119,255 200 0,255 85 255,60 125 255' # 30 comma/space separated values from 0 to 255
 	#twilight
 	mode_hex_twilight='0a' # DO NOT EDIT AT ALL!
-	speeds_hex_twilight='30 35 3a 3f 44 49 4e 53 58 5d 62' # DO NOT EDIT AT ALL! This is a guess, need to find actual hex values set by official app.
+	speeds_hex_twilight='00 19 33 4c 66 7f 99 b2 cc e5 ff' # DO NOT EDIT AT ALL! This is a guess, need to find actual hex values set by official app.
 	speed_default_twilight='9' # min 1, max 11, default 9
 	#teleport
 	mode_hex_teleport='05' # DO NOT EDIT AT ALL!
@@ -144,13 +145,30 @@ function initialize_modes() {
 
 	#ramslots
 	ramslot_one_hex='60' # DO NOT EDIT AT ALL!
+	ramslot_one_value_one_check_hex='48' # DO NOT EDIT AT ALL!
+	ramslot_one_value_two_check_hex='50' # DO NOT EDIT AT ALL!
 	ramslot_two_hex='61' # DO NOT EDIT AT ALL!
+	ramslot_two_value_one_check_hex='49' # DO NOT EDIT AT ALL!
+	ramslot_two_value_two_check_hex='51' # DO NOT EDIT AT ALL!
 	ramslot_three_hex='62' # DO NOT EDIT AT ALL!
+	ramslot_three_value_one_check_hex='4a' # DO NOT EDIT AT ALL!
+	ramslot_three_value_two_check_hex='52' # DO NOT EDIT AT ALL!
 	ramslot_four_hex='63' # DO NOT EDIT AT ALL!
+	ramslot_four_value_one_check_hex='4b' # DO NOT EDIT AT ALL!
+	ramslot_four_value_two_check_hex='53' # DO NOT EDIT AT ALL!
 	ramslot_five_hex='64' # DO NOT EDIT AT ALL!
+	ramslot_five_value_one_check_hex='4c' # DO NOT EDIT AT ALL!
+	ramslot_five_value_two_check_hex='54' # DO NOT EDIT AT ALL!
 	ramslot_six_hex='65' # DO NOT EDIT AT ALL!
+	ramslot_six_value_one_check_hex='4d' # DO NOT EDIT AT ALL!
+	ramslot_six_value_two_check_hex='55' # DO NOT EDIT AT ALL!
 	ramslot_seven_hex='66' # DO NOT EDIT AT ALL!
+	ramslot_seven_value_one_check_hex='4e' # DO NOT EDIT AT ALL!
+	ramslot_seven_value_two_check_hex='56' # DO NOT EDIT AT ALL!
 	ramslot_eight_hex='67' # DO NOT EDIT AT ALL!
+	ramslot_eight_value_one_check_hex='4f' # DO NOT EDIT AT ALL!
+	ramslot_eight_value_two_check_hex='57' # DO NOT EDIT AT ALL!
+	ramslot_value_expected_hex='78' # DO NOT EDIT AT ALL!
 	#inizialize mode
 	inizialize_mode_write='53' # DO NOT EDIT AT ALL!
 	inizialize_mode_to='08' # DO NOT EDIT AT ALL!
@@ -325,11 +343,6 @@ function check_ramsticks() {
 			else
 				ramsticks_hex_conf+=",${ramstick_hex_conf}"
 			fi
-			if [[ -z "${ram_slots}" ]]; then
-				ram_slots="${ramstick}"
-			else
-				ram_slots+=" - ${ramstick}"
-			fi
 		fi
 	done
 	if [[ -z "${ramsticks_hex_conf}" ]]; then
@@ -339,20 +352,139 @@ function check_ramsticks() {
 	fi
 }
 
-function select_i2cbus() {
+# Setting register &0x0b to 0x04 on addresses 0x5[0-7] allows to read the DIMM model name, but
+# very often address 0x5 is write protected (as in my system), which makes this method useless.
+#
+# This function will check if 0x6[0-7], 0x5[0-7] and 0x4[8-f] exist on selected smbus, and in
+# 0x4[8-f] check if registers &0x21, &0x25 and &0x27 are equal to 78. This is not the correct
+# way to detect a 'Kingston Fury Beast DDR5 RGB RAM' because at least the non RGB variant has
+# the same values, but could at least prevent to improperly use this script on most other devices.
+function check_ramsticks_on_smbus() {
 
-	i2cbuses_numbers="$(echo "${i2cbuses}" | grep "^i2c-" | awk '{print $1}' | awk -F'i2c-' '{print $2}')"
-	echo -e "\e[1;32m- Please select an i2c bus number:\e[0m"
-	echo "${i2cbuses}"
-	while true; do
-		read -p " choose> " i2cbus_number
-		if [[ ! "${i2cbus_number}" =~ ^[[:digit:]]+$ ]]; then
-			echo -e "\e[1;31mInvalid choice!\e[0m"
-			sleep '1'
-		else
-			break
+	smbus_detect="$(i2cdetect -y "${smbus_number}")"
+	for ramstick_hex in ${ramsticks_hex//,/$' '}; do
+		if [[ "${ramstick_hex}" = "${ramslot_one_hex}" ]]; then
+			ramslot='1'
+			ramslot_value_one_check_hex="${ramslot_one_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_one_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_two_hex}" ]]; then
+			ramslot='2'
+			ramslot_value_one_check_hex="${ramslot_two_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_two_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_three_hex}" ]]; then
+			ramslot='3'
+			ramslot_value_one_check_hex="${ramslot_three_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_three_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_four_hex}" ]]; then
+			ramslot='4'
+			ramslot_value_one_check_hex="${ramslot_four_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_four_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_five_hex}" ]]; then
+			ramslot='5'
+			ramslot_value_one_check_hex="${ramslot_five_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_five_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_six_hex}" ]]; then
+			ramslot='6'
+			ramslot_value_one_check_hex="${ramslot_six_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_six_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_seven_hex}" ]]; then
+			ramslot='7'
+			ramslot_value_one_check_hex="${ramslot_seven_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_seven_value_two_check_hex}"
+		elif [[ "${ramstick_hex}" = "${ramslot_eight_hex}" ]]; then
+			ramslot='8'
+			ramslot_value_one_check_hex="${ramslot_eight_value_one_check_hex}"
+			ramslot_value_two_check_hex="${ramslot_eight_value_two_check_hex}"
 		fi
+		if ! echo "${smbus_detect}" | grep "^${ramstick_hex:0:1}" | awk -F':' '{print $2}'| grep -q "\ ${ramstick_hex}\ " || ! echo "${smbus_detect}" | grep "^${ramslot_value_one_check_hex:0:1}" | awk -F':' '{print $2}'| grep -q "\ ${ramslot_value_one_check_hex}\ " || ! echo "${smbus_detect}" | grep "^${ramslot_value_two_check_hex:0:1}" | awk -F':' '{print $2}'| grep -q "\ ${ramslot_value_two_check_hex}\ "; then
+			echo
+			echo -e "\e[1;31m- RAM ${ramslot} (0x${ramstick_hex} - 0x${ramslot_value_one_check_hex} - 0x${ramslot_value_two_check_hex}) not found in i2c-${smbus_number}!\e[0m"
+		else
+			current_ram="$(i2cdump -y "${smbus_number}" "0x${ramslot_value_one_check_hex}" b | grep "^20:")"
+			if [[ "$(echo "${current_ram}" | awk '{print $3}')" = "${ramslot_value_expected_hex}" ]] && [[ "$(echo "${current_ram}" | awk '{print $7}')" = "${ramslot_value_expected_hex}" ]] && [[ "$(echo "${current_ram}" | awk '{print $9}')" = "${ramslot_value_expected_hex}" ]]; then
+				set_ramstick_hex
+			else
+				echo
+				echo -e "\e[1;31m- RAM ${ramslot} (0x${ramstick_hex}) in i2c-${smbus_number} doesn't seems to be a Kingston Fury Beast DDR5!\e[0m"
+				#while true; do
+					#disclaimer
+					#echo
+					#echo -e "\e[1;31m- Please make 'REALLY' sure RAM in slot ${ramslot} is a 'Kingston Fury Beast DDR5 RGB'!\e[0m"
+					#echo -e "\e[1;31m- do you still want to mess with RAM in slot ${ramslot}?\e[0m"
+					#echo -e "\e[1;32m0) No\e[0m"
+					#echo -e "\e[1;31m1) Yes\e[0m"
+					#read -p " choose> " set_mode_answer
+					#if [[ ! "${set_mode_answer}" =~ ^[[:digit:]]+$ ]] || [[ "${set_mode_answer}" -gt '1' ]] || [[ "${set_mode_answer}" -lt '0' ]]; then
+						#echo -e "\e[1;31mInvalid choice!\e[0m"
+						#sleep '1'
+					#elif [[ "${set_mode_answer}" -eq '0' ]]; then
+						#break
+					#elif [[ "${set_mode_answer}" -eq '1' ]]; then
+						#set_ramstick_hex
+						#break
+					#fi
+				#done
+			fi
+		fi
+		check_hex_values "${ramstick_hex} ${ramslot_value_one_check_hex} ${ramslot_value_two_check_hex} ${ramslot_value_expected_hex}"
 	done
+	if [[ -z "${ramsticks_hex_check}" ]]; then
+		echo
+		echo -e "\e[1;31m- Selected RAM Sticks not found in i2c-${smbus_number}!\e[0m"
+		exit 1
+	else
+		ramsticks_hex=" ${ramsticks_hex_check}"
+	fi
+}
+
+function set_ramstick_hex() {
+
+	if [[ -z "${ramsticks_hex_check}" ]]; then
+		ramsticks_hex_check="${ramstick_hex}"
+	else
+		ramsticks_hex_check+=" ${ramstick_hex}"
+	fi
+	if [[ -z "${ram_slots}" ]]; then
+		ram_slots="${ramslot}"
+	else
+		ram_slots+=" - ${ramslot}"
+	fi
+}
+
+function select_smbus() {
+
+	echo
+	echo -e "\e[1;32m- Please select an SMBus (or type 'quit' to exit from ${kfrgb_name}:\e[0m"
+	unset n
+	while IFS= read -r smbus; do
+		if [[ "$(echo "${smbus}" | grep -E "^i2c-[[:digit:]]+" | awk '{print $2}')" = 'smbus' ]]; then
+			n="$(echo "${smbus}" | awk '{print $1}' | awk -F'i2c-' '{print $2}')"
+			if [[ "${n}" -le '9' ]]; then
+				sp1=" "
+			else
+				sp1=""
+			fi
+			echo "${sp1}${n}) ${smbus}"
+		fi
+	done <<< "${i2cbuses}"
+
+	if [[ -z "${n}" ]]; then
+		echo -e "\e[1;31mNo SMBus found!\e[0m"
+		exit 1
+	else
+		while true; do
+			read -p " choose> " smbus_number
+			if [[ "${smbus_number,,}" = 'quit' ]]; then
+				echo -e "\e[1;33mexit\e[0m"
+				exit 0
+			elif [[ ! "${smbus_number}" =~ ^[[:digit:]]+$ ]]; then
+				echo -e "\e[1;31mInvalid choice!\e[0m"
+				sleep '1'
+			else
+				break
+			fi
+		done
+	fi
 }
 
 function list_modes() {
@@ -372,7 +504,7 @@ function list_modes() {
 	done
 	while true; do
 		read -rp " choose> " selected_mode
-		if [[ ! "${selected_mode}" =~ ^[[:digit:]]+$ ]] || [[ "${selected_mode}" -gt "${i}" ]]; then
+		if [[ ! "${selected_mode}" =~ ^[[:digit:]]+$ ]] || [[ "${selected_mode}" =~ ^0[[:digit:]]+$ ]] || [[ "${selected_mode}" -gt "${i}" ]]; then
 			echo -e "\e[1;31mInvalid choice!\e[0m"
 			sleep '1'
 		else
@@ -1038,9 +1170,8 @@ function check_values() {
 function set_mode() {
 
 	echo
-	echo -e "\e[0;32m- i2c bus: $(echo "${i2cbuses}" | grep "^i2c-${i2cbus_number}" | sed -e "s/[[:space:]]\+/ /g")\e[0m"
+	echo -e "\e[0;32m- SMBus: $(echo "${i2cbuses}" | grep "^i2c-${smbus_number}" | sed -e "s/[[:space:]]\+/ /g")\e[0m"
 	echo -e "\e[0;32m- RAM Slots: ${ram_slots}\e[0m"
-	check_hex_values "${ramsticks_hex}"
 	echo
 	echo -e "\e[0;32m- Mode: ${mode}\e[0m"
 	check_hex_values "${inizialize_mode_write} ${inizialize_mode_to} ${finalize_mode_write} ${set_mode_to} ${mode_hex}"
@@ -1121,12 +1252,7 @@ function set_mode() {
 	fi
 
 	if [[ "${nowarn}" != 'true' ]]; then
-		echo
-		echo -e "\e[1;31m- ### DISCLAIMER\e[0m"
-		echo -e "\e[1;31m- Detection of a Kingston Fury Beast DDR5 RAM on a i2c-bus is not implemented, so you must be really sure about the values you enter for --ramslots and --bus.\e[0m"
-		echo -e "\e[1;31m- To find out how to retrieve these values, please refer to https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/2879.\e[0m"
-		echo -e "\e[1;31m- Even if you enter the correct values, the procedure is still risky!\e[0m"
-		echo -e "\e[1;31m- This program can confuse your I2C bus, cause data loss or brick your hardware! Proceed AT YOUR OWN RISK!\e[0m"
+		disclaimer
 		while true; do
 			echo
 			echo -e "\e[1;31m- do you want to proceed?\e[0m"
@@ -1145,252 +1271,230 @@ function set_mode() {
 		done
 	fi
 
-	i2cbus_detect="$(i2cdetect -y "${i2cbus_number}")"
 	if [[ ! "${wait}" =~ ^[[:digit:]]+(.[[:digit:]]+)?$ ]]; then
 		wait='0.015'
 	fi
 	echo
 	for ramstick_hex in ${ramsticks_hex//,/$' '}; do
-		if [[ "${ramstick_hex}" = "${ramslot_one_hex}" ]]; then
-			ramslot='1'
-		elif [[ "${ramstick_hex}" = "${ramslot_two_hex}" ]]; then
-			ramslot='2'
-		elif [[ "${ramstick_hex}" = "${ramslot_three_hex}" ]]; then
-			ramslot='3'
-		elif [[ "${ramstick_hex}" = "${ramslot_four_hex}" ]]; then
-			ramslot='4'
-		elif [[ "${ramstick_hex}" = "${ramslot_five_hex}" ]]; then
-			ramslot='5'
-		elif [[ "${ramstick_hex}" = "${ramslot_six_hex}" ]]; then
-			ramslot='6'
-		elif [[ "${ramstick_hex}" = "${ramslot_seven_hex}" ]]; then
-			ramslot='7'
-		elif [[ "${ramstick_hex}" = "${ramslot_eight_hex}" ]]; then
-			ramslot='8'
+		echo -e "\e[1;33m- Setting mode ${mode} for RAM on slot ${ramslot}\e[0m"
+		i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${inizialize_mode_to}" "0x${inizialize_mode_write}"
+		sleep "${wait}"
+		i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_mode_to}" "0x${mode_hex}"
+		sleep "${wait}"
+		if check_mode "${supported_speed}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_speed_to}" "0x${speed_hex}"
+			sleep "${wait}"
 		fi
-		if ! echo "${i2cbus_detect}" | grep "^${ramstick_hex:0:1}" | awk -F':' '{print $2}'| grep -q "\ ${ramstick_hex}\ "; then
-			echo -e "\e[1;31m- RAM ${ramslot} (0x${ramstick_hex}) not found in i2c-${i2cbus_number}! skipping.\e[0m"
-		else
-			echo -e "\e[1;33m- Setting mode ${mode} for ram ${ramslot}\e[0m"
-			i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${inizialize_mode_to}" "0x${inizialize_mode_write}"
+		if check_mode "${supported_delay}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_delay_to}" "0x${delay_hex}"
 			sleep "${wait}"
-			i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_mode_to}" "0x${mode_hex}"
-			sleep "${wait}"
-			if check_mode "${supported_speed}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_speed_to}" "0x${speed_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_delay}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_delay_to}" "0x${delay_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_length}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_length_to}" "0x${length_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_tencolors}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolorsnumber_to}" "0x${tencolorsnumber_hex}"
-				sleep "${wait}"
-				
-				if [[ '1' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_red_to}" "0x${tencolor_1_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_green_to}" "0x${tencolor_1_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_blue_to}" "0x${tencolor_1_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '2' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_red_to}" "0x${tencolor_2_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_green_to}" "0x${tencolor_2_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_blue_to}" "0x${tencolor_2_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '3' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_red_to}" "0x${tencolor_3_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_green_to}" "0x${tencolor_3_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_blue_to}" "0x${tencolor_3_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '4' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_red_to}" "0x${tencolor_4_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_green_to}" "0x${tencolor_4_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_blue_to}" "0x${tencolor_4_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '5' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_red_to}" "0x${tencolor_5_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_green_to}" "0x${tencolor_5_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_blue_to}" "0x${tencolor_5_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '6' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_red_to}" "0x${tencolor_6_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_green_to}" "0x${tencolor_6_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_blue_to}" "0x${tencolor_6_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '7' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_red_to}" "0x${tencolor_7_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_green_to}" "0x${tencolor_7_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_blue_to}" "0x${tencolor_7_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '8' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_red_to}" "0x${tencolor_8_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_green_to}" "0x${tencolor_8_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_blue_to}" "0x${tencolor_8_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '9' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_red_to}" "0x${tencolor_9_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_green_to}" "0x${tencolor_9_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_blue_to}" "0x${tencolor_9_blue_hex}"
-					sleep "${wait}"
-				fi
-
-				if [[ '10' -le "${tencolorsnumber}" ]]; then
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_red_to}" "0x${tencolor_10_red_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_green_to}" "0x${tencolor_10_green_hex}"
-					sleep "${wait}"
-					i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_blue_to}" "0x${tencolor_10_blue_hex}"
-					sleep "${wait}"
-				fi
-			fi
-			if check_mode "${supported_backcolor}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_red_to}" "0x${backcolor_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_green_to}" "0x${backcolor_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_blue_to}" "0x${backcolor_blue_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_allcolor}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_red_to}" "0x${allcolor_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_green_to}" "0x${allcolor_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_blue_to}" "0x${allcolor_blue_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_byledcolor}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_red_to}" "0x${byledcolor_1_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_green_to}" "0x${byledcolor_1_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_blue_to}" "0x${byledcolor_1_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_red_to}" "0x${byledcolor_2_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_green_to}" "0x${byledcolor_2_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_blue_to}" "0x${byledcolor_2_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_red_to}" "0x${byledcolor_3_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_green_to}" "0x${byledcolor_3_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_blue_to}" "0x${byledcolor_3_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_red_to}" "0x${byledcolor_4_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_green_to}" "0x${byledcolor_4_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_blue_to}" "0x${byledcolor_4_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_red_to}" "0x${byledcolor_5_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_green_to}" "0x${byledcolor_5_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_blue_to}" "0x${byledcolor_5_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_red_to}" "0x${byledcolor_6_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_green_to}" "0x${byledcolor_6_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_blue_to}" "0x${byledcolor_6_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_red_to}" "0x${byledcolor_7_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_green_to}" "0x${byledcolor_7_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_blue_to}" "0x${byledcolor_7_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_red_to}" "0x${byledcolor_8_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_green_to}" "0x${byledcolor_8_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_blue_to}" "0x${byledcolor_8_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_red_to}" "0x${byledcolor_9_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_green_to}" "0x${byledcolor_9_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_blue_to}" "0x${byledcolor_9_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_red_to}" "0x${byledcolor_10_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_green_to}" "0x${byledcolor_10_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_blue_to}" "0x${byledcolor_10_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_red_to}" "0x${byledcolor_11_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_green_to}" "0x${byledcolor_11_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_blue_to}" "0x${byledcolor_11_blue_hex}"
-				sleep "${wait}"
-
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_red_to}" "0x${byledcolor_12_red_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_green_to}" "0x${byledcolor_12_green_hex}"
-				sleep "${wait}"
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_blue_to}" "0x${byledcolor_12_blue_hex}"
-				sleep "${wait}"
-			fi
-			if check_mode "${supported_direction}"; then
-				i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_direction_to}" "0x${direction_hex}"
-				sleep "${wait}"
-			fi
-			i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${set_brightness_to}" "0x${brightness_hex}"
-			sleep "${wait}"
-			i2cset_retry -y "${i2cbus_number}" "0x${ramstick_hex}" "0x${inizialize_mode_to}" "0x${finalize_mode_write}"
 		fi
+		if check_mode "${supported_length}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_length_to}" "0x${length_hex}"
+			sleep "${wait}"
+		fi
+		if check_mode "${supported_tencolors}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolorsnumber_to}" "0x${tencolorsnumber_hex}"
+			sleep "${wait}"
+			
+			if [[ '1' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_red_to}" "0x${tencolor_1_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_green_to}" "0x${tencolor_1_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_1_blue_to}" "0x${tencolor_1_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '2' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_red_to}" "0x${tencolor_2_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_green_to}" "0x${tencolor_2_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_2_blue_to}" "0x${tencolor_2_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '3' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_red_to}" "0x${tencolor_3_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_green_to}" "0x${tencolor_3_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_3_blue_to}" "0x${tencolor_3_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '4' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_red_to}" "0x${tencolor_4_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_green_to}" "0x${tencolor_4_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_4_blue_to}" "0x${tencolor_4_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '5' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_red_to}" "0x${tencolor_5_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_green_to}" "0x${tencolor_5_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_5_blue_to}" "0x${tencolor_5_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '6' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_red_to}" "0x${tencolor_6_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_green_to}" "0x${tencolor_6_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_6_blue_to}" "0x${tencolor_6_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '7' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_red_to}" "0x${tencolor_7_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_green_to}" "0x${tencolor_7_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_7_blue_to}" "0x${tencolor_7_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '8' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_red_to}" "0x${tencolor_8_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_green_to}" "0x${tencolor_8_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_8_blue_to}" "0x${tencolor_8_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '9' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_red_to}" "0x${tencolor_9_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_green_to}" "0x${tencolor_9_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_9_blue_to}" "0x${tencolor_9_blue_hex}"
+				sleep "${wait}"
+			fi
+
+			if [[ '10' -le "${tencolorsnumber}" ]]; then
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_red_to}" "0x${tencolor_10_red_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_green_to}" "0x${tencolor_10_green_hex}"
+				sleep "${wait}"
+				i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_tencolor_10_blue_to}" "0x${tencolor_10_blue_hex}"
+				sleep "${wait}"
+			fi
+		fi
+		if check_mode "${supported_backcolor}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_red_to}" "0x${backcolor_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_green_to}" "0x${backcolor_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_backcolor_blue_to}" "0x${backcolor_blue_hex}"
+			sleep "${wait}"
+		fi
+		if check_mode "${supported_allcolor}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_red_to}" "0x${allcolor_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_green_to}" "0x${allcolor_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_allcolor_blue_to}" "0x${allcolor_blue_hex}"
+			sleep "${wait}"
+		fi
+		if check_mode "${supported_byledcolor}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_red_to}" "0x${byledcolor_1_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_green_to}" "0x${byledcolor_1_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_1_blue_to}" "0x${byledcolor_1_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_red_to}" "0x${byledcolor_2_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_green_to}" "0x${byledcolor_2_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_2_blue_to}" "0x${byledcolor_2_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_red_to}" "0x${byledcolor_3_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_green_to}" "0x${byledcolor_3_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_3_blue_to}" "0x${byledcolor_3_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_red_to}" "0x${byledcolor_4_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_green_to}" "0x${byledcolor_4_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_4_blue_to}" "0x${byledcolor_4_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_red_to}" "0x${byledcolor_5_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_green_to}" "0x${byledcolor_5_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_5_blue_to}" "0x${byledcolor_5_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_red_to}" "0x${byledcolor_6_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_green_to}" "0x${byledcolor_6_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_6_blue_to}" "0x${byledcolor_6_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_red_to}" "0x${byledcolor_7_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_green_to}" "0x${byledcolor_7_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_7_blue_to}" "0x${byledcolor_7_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_red_to}" "0x${byledcolor_8_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_green_to}" "0x${byledcolor_8_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_8_blue_to}" "0x${byledcolor_8_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_red_to}" "0x${byledcolor_9_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_green_to}" "0x${byledcolor_9_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_9_blue_to}" "0x${byledcolor_9_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_red_to}" "0x${byledcolor_10_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_green_to}" "0x${byledcolor_10_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_10_blue_to}" "0x${byledcolor_10_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_red_to}" "0x${byledcolor_11_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_green_to}" "0x${byledcolor_11_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_11_blue_to}" "0x${byledcolor_11_blue_hex}"
+			sleep "${wait}"
+
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_red_to}" "0x${byledcolor_12_red_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_green_to}" "0x${byledcolor_12_green_hex}"
+			sleep "${wait}"
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_byledcolor_12_blue_to}" "0x${byledcolor_12_blue_hex}"
+			sleep "${wait}"
+		fi
+		if check_mode "${supported_direction}"; then
+			i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_direction_to}" "0x${direction_hex}"
+			sleep "${wait}"
+		fi
+		i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${set_brightness_to}" "0x${brightness_hex}"
+		sleep "${wait}"
+		i2cset_retry -y "${smbus_number}" "0x${ramstick_hex}" "0x${inizialize_mode_to}" "0x${finalize_mode_write}"
 	done
 }
 
@@ -1408,8 +1512,29 @@ function i2cset_retry() {
 			echo -e "\e[1;31m- Maximum retries reached, aborting!\e[0m"
 			exit 1
 		fi
-		sleep "${wait}"
+		if [[ "${retry_count}" -le '10' ]]; then
+			sleep 0.030
+		elif [[ "${retry_count}" -ge '11' ]] && [[ "${retry_count}" -le '13' ]]; then
+			#echo -e "\e[1;33m - Please wait...\e[0m"
+			sleep 1
+		elif [[ "${retry_count}" -ge '14' ]] && [[ "${retry_count}" -le '16' ]]; then
+			echo -e "\e[1;33m - Please wait...\e[0m"
+			sleep 3
+		elif [[ "${retry_count}" -ge '17' ]] && [[ "${retry_count}" -le '20' ]]; then
+			echo -e "\e[1;33m - Please wait...\e[0m"
+			sleep 5
+		fi
 	done
+}
+
+function disclaimer() {
+
+	echo
+	echo -e "\e[1;31m- ### DISCLAIMER\e[0m"
+	echo -e "\e[1;31m- Detection of a 'Kingston Fury Beast DDR5 RGB RAM' on an SMBus is not implemented, so you must be really sure about the values you enter for --ramslots and --smbus.\e[0m"
+	echo -e "\e[1;31m- To find out how to retrieve these values, please refer to https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/2879.\e[0m"
+	echo -e "\e[1;31m- Even if you enter the correct values, the procedure is still risky!\e[0m"
+	echo -e "\e[1;31m- This program can confuse your I2C bus, cause data loss or brick your hardware! Proceed AT YOUR OWN RISK!\e[0m"
 }
 
 function givemehelp() {
@@ -1417,13 +1542,13 @@ function givemehelp() {
 	echo "
 # kfrgb
 
-# Version:    0.5.0
+# Version:    0.6.0
 # Author:     KeyofBlueS
 # Repository: https://github.com/KeyofBlueS/kfrgb
 # License:    GNU General Public License v3.0, https://opensource.org/licenses/GPL-3.0
 
 ### DISCLAIMER
-Detection of a Kingston Fury Beast DDR5 RAM on a i2c-bus is not implemented, so you must be really sure about the values you enter for --ramslots and --bus.
+Detection of a 'Kingston Fury Beast DDR5 RGB RAM' on an SMBus is not implemented, so you must be really sure about the values you enter for --ramslots and --smbus.
 To find out how to retrieve these values, please refer to https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/2879.
 Even if you enter the correct values, the procedure is still risky!
 This program can confuse your I2C bus, cause data loss or brick your hardware! Proceed AT YOUR OWN RISK!
@@ -1432,23 +1557,23 @@ This program can confuse your I2C bus, cause data loss or brick your hardware! P
 While waiting for support to be added to OpenRGB, this script is intended to be used to control RGB Leds of a Kingston Fury Beast DDR5 RAM ONLY with the help of i2c-tools.
 
 ### FEATURES
-Set any mode (and their parameters) between rainbow, prism, spectrum, slide, wind, static, static_byledcolor, lightspeed, rain, firework, twilight, teleport, flame, voltage, countdown and rhythm.
+Set any mode (and their parameters) between rainbow, prism, spectrum, slide, wind, static, static_byledcolor, lightspeed, rain, firework, breath, breath_byledcolor, dynamic, twilight, teleport, flame, voltage, countdown and rhythm.
 By using yad, a graphical dialog to choose a color is shown if no\wrong values for them are entered.
 
 Not all modes are fully supported:
-- Modes breath, breath_byledcolor and dynamic: not supported because if set, then you can't set any other mode, you need to turn off the pc (do a cold boot) to 'unlock' (and we lack the hex values to set speed).
 - Mode slither: not supported (we lack the hex values to set this mode and its parameters).
 - Modes twilight, teleport, flame, voltage, countdown and rhythm: we lack the hex values to set any of their parameters, nevertheless i've used values from other modes to set them. It works, but likely not the same way as with the official app.
+- Modes breath, breath_byledcolor and dynamic: we lack the hex values to set speed, values from other modes doesn't work. These modes will run at their default speed or the last speed set by the official app.
 
 ### USAGE
-The option --ramslots <ramslots_value> is mandatory. The value equals a ram slot. Accept values from 1 to 8.
-You can enter a single value to control a single ram stick or a comma separated set of values to control two or more ram sticks.
-If you enter e.g. --ramslots 2,4 on --bus 0, but you really only have ram 2, ram 4 will be skipped.
+The option --ramslots <ramslots_value> is mandatory. The value equals a RAM slot. Accept values from 1 to 8.
+You can enter a single value to control a single RAM stick or a comma separated set of values to control two or more RAM sticks.
+If you enter e.g. --ramslots 2,4 on --smbus 0, but you really only have RAM 2, RAM 4 will be skipped.
 
-If the option --bus <i2c_bus_number> is omitted or a wrong/non existent value has been entered, a prompt to select an i2c-bus will be shown.
+If the option --smbus <smbus_number> is omitted or a wrong/non existent value has been entered, a prompt to select an SMBus will be shown.
 
 Use the option --mode <mode_name> to set a mode.
-Available modes are 'rainbow' 'prism' 'spectrum' 'slide' 'wind' 'static' 'static_byledcolor' 'lightspeed' 'rain' 'firework' 'twilight' 'teleport' 'flame' 'voltage' 'countdown' 'rhythm'.
+Available modes are 'rainbow' 'prism' 'spectrum' 'slide' 'wind' 'static' 'static_byledcolor' 'lightspeed' 'rain' 'firework' 'breath' 'breath_byledcolor' 'dynamic' 'twilight' 'teleport' 'flame' 'voltage' 'countdown' 'rhythm'.
 Pass 'list' as <mode_name> to get a menu where you can choose a mode to set.
 
 Speed (min 1, max 11) and brightness (min 0, max 100, default 80) are common for every mode. However every mode has it's own available and default parameters also:
@@ -1462,6 +1587,9 @@ Speed (min 1, max 11) and brightness (min 0, max 100, default 80) are common for
 - lightspeed: speed (default 9); delay (min 1, max 21, default 1); lenght (min 1, max 18, default 7); tencolors; direction (default up).
 - rain: speed (default 11); tencolors; direction (default down).
 - firework: speed (default 11); tencolors; direction (default up).
+- breath: tencolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
+- breath_byledcolor: byledcolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
+- dynamic: tencolors. Setting speed not supported, will run at its default speed or the last speed set by the official app.
 - twilight: speed (default 9).
 - teleport: speed (default 10); lenght (min 1, max 12, default 3); tencolors; backcolor; direction (default up).
 - flame: speed (default 1); direction (default up).
@@ -1488,7 +1616,7 @@ One color is expressed with 3 comma separated values for RGB. So 255,255,255 mea
 Option --color <r_value,g_value,b_value> accept 3 comma separated values from 0 to 255.
 Use this option to set a color in mode static.
 
-Option --byledcolors <byledcolors_values> accept 36 comma separated values from 0 to 255. Every three values equals a color (36 values are 12 colors, this ram has 12 leds indeed).
+Option --byledcolors <byledcolors_values> accept 36 comma separated values from 0 to 255. Every three values equals a color (36 values are 12 colors, this RAM has 12 leds indeed).
 Use this option to set every single led color in the supported mode (static_byledcolor).
 
 Option --tencolors <tencolors_values> accept 30 comma separated values from 0 to 255. Every three values equals a color (30 values are 10 colors).
@@ -1517,57 +1645,57 @@ Option --wait <wait_value> will set the sleep time between i2cset commands. Acce
 If no\wrong value has been entered, the wait time will default to 0.015.
 Anyway this script will retry (for at most 20 times and then will abort) if an i2cset command fails, so you can keep wait time very low and don't worry about write errors.
 
-Option --off will turn off leds on the ram. This option will take full priority over any other option.
+Option --off will turn off leds on the RAM. This option will take full priority over any other option.
 
 ### EXAMPLES
 
-show a menu where you can select an i2c-bus, then choose a mode to set for ram 2:
+show a menu where you can select an SMBus, then choose a mode to set for RAM 2:
 # ${kfrgb_name} --ramslots 2
 
-show a menu where you can choose a mode to set for ram 2 on i2c-bus 0:
-# ${kfrgb_name} --ramslots 2 --bus 0
+show a menu where you can choose a mode to set for RAM 2 on SMBus 0:
+# ${kfrgb_name} --ramslots 2 --smbus 0
 
-show a graphical dialog to choose a color with brightness at 70 for ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --brightness 70 --mode static --ask --nowarn
+show a graphical dialog to choose a color with brightness at 70 for RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --brightness 70 --mode static --ask --nowarn
 
-set a yellow color to ram 2 and 4 on i2c-bus 0 (in this case the options --mode static):
-# ${kfrgb_name} --ramslots 2,4 --bus 0 --color 255,255,0
+set a yellow color to RAM 2 and 4 on SMBus 0 (in this case the options --mode static):
+# ${kfrgb_name} --ramslots 2,4 --smbus 0 --color 255,255,0
 
-set a every single led color to ram 2 and 4 on i2c-bus 0:
-# ${kfrgb_name} --ramslots 2,4 --bus 0 --mode static_byledcolor --byledcolors 255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255
+set a every single led color to RAM 2 and 4 on SMBus 0:
+# ${kfrgb_name} --ramslots 2,4 --smbus 0 --mode static_byledcolor --byledcolors 255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255,255,0,0,0,255,0,0,0,255
 
-set a every single led to a random color to ram 2 and 4 on i2c-bus 0:
-# ${kfrgb_name} --ramslots 2,4 --bus 0 --mode static_byledcolor --randomcolor
+set a every single led to a random color to RAM 2 and 4 on SMBus 0:
+# ${kfrgb_name} --ramslots 2,4 --smbus 0 --mode static_byledcolor --randomcolor
 
-set mode wind with default parameters to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode wind --nowarn
+set mode wind with default parameters to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode wind --nowarn
 
-set mode wind with brightness at 100 and direction down to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode wind --brightness 100 --direction down --nowarn
+set mode wind with brightness at 100 and direction down to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode wind --brightness 100 --direction down --nowarn
 
-set mode wind with backcolor to violet, brightness at 100 and direction down to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode wind --backcolor 150,70,200 --brightness 100 --direction down --nowarn
+set mode wind with backcolor to violet, brightness at 100 and direction down to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode wind --backcolor 150,70,200 --brightness 100 --direction down --nowarn
 
-set mode slide with speed at 8 and direction up to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode slide --speed 8 --direction up --nowarn
+set mode slide with speed at 8 and direction up to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode slide --speed 8 --direction up --nowarn
 
-set mode rainbow with speed at 1 to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode rainbow --speed 1 --nowarn
+set mode rainbow with speed at 1 to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode rainbow --speed 1 --nowarn
 
-set mode slide and 10 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0,0,0,255,238,238,0,128,0,128,0,109,119,255,200,0,255,85,255,60,125,255 --nowarn
+set mode slide and 10 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0,0,0,255,238,238,0,128,0,128,0,109,119,255,200,0,255,85,255,60,125,255 --nowarn
 
-set mode slide and 3 colors (you can omit the remaining 7 colors) to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0 --tencolorsnumber 3 --nowarn
+set mode slide and 3 colors (you can omit the remaining 7 colors) to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode slide --tencolors 255,0,0,0,255,0,255,100,0 --tencolorsnumber 3 --nowarn
 
-set mode wind and, asking for user input, 10 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode wind --ask --nowarn
+set mode wind and, asking for user input, 10 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode wind --ask --nowarn
 
-set mode wind and, asking for user input, 3 colors to cycle through to ram 2 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 2 --bus 0 --mode wind --tencolorsnumber 3 --ask --nowarn
+set mode wind and, asking for user input, 3 colors to cycle through to RAM 2 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 2 --smbus 0 --mode wind --tencolorsnumber 3 --ask --nowarn
 
-Turn off leds to ram 4 on i2c-bus 0 without the warning before apply the settings:
-# ${kfrgb_name} --ramslots 4 --bus 0 --off --nowarn
+Turn off leds to RAM 4 on SMBus 0 without the warning before apply the settings:
+# ${kfrgb_name} --ramslots 4 --smbus 0 --off --nowarn
 
 ### NOTE ABOUT COMMA SEPARATED VALUES
 As explained above, RGB values can be set in a comma separated format e.g.:
@@ -1580,8 +1708,8 @@ I prefer the latter because i can visually separate every RGB triplet.
 
 
 Options:
--s, --bus <i2c_bus_number>      Enter the i2c-bus number.
--m, --ramslots <ramslots_value> Enter the comma separated ram slot values. Mandatory.
+-s, --smbus <smbus_number>      Enter the SMBus number.
+-m, --ramslots <ramslots_value> Enter the comma separated RAM slot values. Mandatory.
 -d, --mode <mode>               Enter the name of the mode. Pass 'list' as <mode_name> to get a menu
                                                             where you can choose a mode to set.
 -p, --speed <value>             Enter  1 value between 1 and 11. Default depends on mode.
@@ -1637,21 +1765,21 @@ if ! command -v "${kfrgb_name}" > /dev/null; then
 fi
 
 modes='rainbow prism spectrum slide wind static static_byledcolor lightspeed rain firework breath breath_byledcolor dynamic twilight teleport flame voltage countdown rhythm slither'
-supported_modes='rainbow prism spectrum slide wind static static_byledcolor lightspeed rain firework twilight teleport flame voltage countdown rhythm'
-unsupported_modes='breath breath_byledcolor dynamic slither'
+supported_modes='rainbow prism spectrum slide wind static static_byledcolor lightspeed rain firework breath breath_byledcolor dynamic twilight teleport flame voltage countdown rhythm'
+unsupported_modes='slither'
 supported_speed='rainbow prism spectrum slide wind lightspeed rain firework twilight teleport flame voltage countdown rhythm' # breath breath_byledcolor dynamic
 supported_delay='prism spectrum slide wind lightspeed rhythm'
 supported_length='slide wind lightspeed teleport'
-supported_tencolors='slide wind lightspeed rain firework teleport voltage countdown rhythm' # breath dynamic
+supported_tencolors='slide wind lightspeed rain firework breath dynamic teleport voltage countdown rhythm'
 supported_backcolor='slide wind teleport voltage countdown rhythm'
-supported_byledcolor='static_byledcolor' # breath_byledcolor
+supported_byledcolor='static_byledcolor breath_byledcolor'
 supported_allcolor='static'
 supported_direction='rainbow spectrum slide wind lightspeed rain firework teleport flame countdown rhythm'
 
 for opt in "$@"; do
 	shift
 	case "$opt" in
-		'--bus')				set -- "$@" '-s' ;;
+		'--smbus')				set -- "$@" '-s' ;;
 		'--ramslots')			set -- "$@" '-m' ;;
 		'--mode')				set -- "$@" '-d' ;;
 		'--speed')				set -- "$@" '-p' ;;
@@ -1676,7 +1804,7 @@ done
 
 while getopts "s:m:d:p:e:q:i:c:b:t:u:k:zl:ow:nah" opt; do
 	case ${opt} in
-		s ) i2cbus_number="${OPTARG}"
+		s ) smbus_number="${OPTARG}"
 		;;
 		m ) ramsticks="${OPTARG}"
 		;;
@@ -1734,15 +1862,27 @@ fi
 
 i2cbuses="$(i2cdetect -l)"
 while true; do
-	if [[ -z "${i2cbus_number}" ]] || ! echo "${i2cbuses}" | grep -q "^i2c-${i2cbus_number}"; then
-		if [[ -z "${i2cbus_number}" ]]; then
+	if [[ -z "${smbus_number}" ]] || ! echo "${i2cbuses}" | grep -q "^i2c-${smbus_number}"; then
+		if [[ -z "${smbus_number}" ]]; then
 			true
 		else
-			echo -e "\e[1;31m- bus i2c-${i2cbus_number}: not found!\e[0m"
+			echo
+			echo -e "\e[1;31m- bus i2c-${smbus_number}: not found!\e[0m"
 		fi
-		select_i2cbus
+		select_smbus
 	else
-		break
+		if [[ "$(echo "${i2cbuses}" | grep "^i2c-${smbus_number}" | awk '{print $2}')" != 'smbus' ]]; then
+			echo
+			echo -e "\e[1;31m- bus i2c-${smbus_number}: is not an SMBus!\e[0m"
+			unset smbus_number
+		elif [[ "$(i2cdetect -F "${smbus_number}" | grep "^SMBus Quick Command" | rev | awk '{print $1}' | rev)" = 'no' ]]; then
+			echo
+			echo -e "\e[1;31m- bus i2c-${smbus_number}: do not support SMBus Quick Command!\e[0m"
+			unset smbus_number
+		else
+			check_ramsticks_on_smbus
+			break
+		fi
 	fi
 done
 
@@ -1768,6 +1908,7 @@ if check_mode "${modes} list"; then
 		list_modes
 	fi
 	if check_mode "${unsupported_modes}"; then
+		echo
 		echo -e "\e[1;31m- Mode ${mode}: currently not supported!\e[0m"
 		exit 1
 	else


### PR DESCRIPTION
- Check and list SMBus only, and excluding those which do not support SMBus Quick Command.

- Function i2cset_retry improved, it now increases the sleep time if a certain value of retries is reached. This allows modes breath, breath_byledcolor and dynamic to be enabled.

- Enable modes breath, breath_byledcolor and dynamic:
We lack the hex values to set speed, values from other modes doesn't work. These modes will run at their default speed or the last speed set by the official app.

- Changed speed for mode twilight to resemble the official app.

- Add a very basic detection for a Kingston Fury Beast DDR5:
Setting register &0x0b to 0x04 on addresses 0x5[0-7] allows to read the DIMM model name, but very often address 0x5 is write protected (as in my system), which makes this method useless.
The script will check if 0x6[0-7], 0x5[0-7] and 0x4[8-f] exist on selected smbus, and in 0x4[8-f] check if registers &0x21, &0x25 and &0x27 are equal to 78. This is not the correct way to detect a 'Kingston Fury Beast DDR5 RGB RAM' because at least the non RGB variant has the same values, but could at least prevent to improperly use this script on most other devices.

- Other minor improvements and optimizations.