### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # kfrgb
 
-# Version:    0.9.5
+# Version:    0.9.6
 # Author:     KeyofBlueS
 # Repository: https://github.com/KeyofBlueS/kfrgb
 # License:    GNU General Public License v3.0, https://opensource.org/licenses/GPL-3.0


### PR DESCRIPTION
- Disable code for checking on address 0x4[8-f] check if registers &0x21 and &0x25 are both =78 OR =b4 and &0x27=78, as it seems to be inconsistent and in definitive not needed.

- Add support for Kingston Fury Beast 0x12